### PR TITLE
Fix test failure on windows.

### DIFF
--- a/tests/it.rs
+++ b/tests/it.rs
@@ -9,6 +9,9 @@ fn to_ref_html(source: &str, matches: bool) -> String {
   sh.change_dir("ref");
   let matches = if matches { Some("-m") } else { None };
   let mut html = xshell::cmd!(sh, "lua ./bin/main.lua {matches...}").stdin(source).read().unwrap();
+  if cfg!(windows) {
+    html = html.replace("\r\n", "\n");
+  }
   html.push('\n');
   html
 }


### PR DESCRIPTION
The lua on windows seems generating html with CRLF eols, and this causes test failures. Also maybe setup ci?